### PR TITLE
add arpc.HandleFree()

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -1117,6 +1117,11 @@ func HandleMalloc(f func(int) []byte) {
 	DefaultHandler.HandleMalloc(f)
 }
 
+// HandleFree registers buffer releaser.
+func HandleFree(f func([]byte)) {
+	DefaultHandler.HandleFree(f)
+}
+
 // EnablePool registers handlers for pool operation for Context and Message and Message.Buffer
 func EnablePool(enable bool) {
 	DefaultHandler.EnablePool(enable)

--- a/handler_test.go
+++ b/handler_test.go
@@ -170,5 +170,6 @@ func TestSetHandler(t *testing.T) {
 	Handle("nothing", func(*Context) {}, true)
 	HandleNotFound(func(*Context) {})
 	HandleMalloc(func(int) []byte { return nil })
+	HandleFree(func([]byte) {})
 	SetHandler(d)
 }


### PR DESCRIPTION
Maybe we need to add `arpc.HandleFree(buf []byte) {}`,

Currently there is only `arpc.HandleMalloc(func(size int) []byte {}`,

Its effect is the same as: `arpc.DefaultHandler.HandleFree(func(buf []byte) {}`